### PR TITLE
Fix a nil dereference in collectCPU where stat.Cpu is nil when a vm is powered off

### DIFF
--- a/collectors/domain_stats.go
+++ b/collectors/domain_stats.go
@@ -371,21 +371,23 @@ func (c *DomainStatsCollector) collectState(uuid string, stat libvirt.DomainStat
 }
 
 func (c *DomainStatsCollector) collectCPU(uuid string, stat libvirt.DomainStats, ch chan<- prometheus.Metric) {
-	ch <- prometheus.MustNewConstMetric(
-		c.DomainCPUTime,
-		prometheus.CounterValue,
-		float64(stat.Cpu.Time), uuid,
-	)
-	ch <- prometheus.MustNewConstMetric(
-		c.DomainCPUUser,
-		prometheus.CounterValue,
-		float64(stat.Cpu.User), uuid,
-	)
-	ch <- prometheus.MustNewConstMetric(
-		c.DomainCPUSystem,
-		prometheus.CounterValue,
-		float64(stat.Cpu.System), uuid,
-	)
+	if stat.Cpu != nil {
+		ch <- prometheus.MustNewConstMetric(
+			c.DomainCPUTime,
+			prometheus.CounterValue,
+			float64(stat.Cpu.Time), uuid,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.DomainCPUUser,
+			prometheus.CounterValue,
+			float64(stat.Cpu.User), uuid,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.DomainCPUSystem,
+			prometheus.CounterValue,
+			float64(stat.Cpu.System), uuid,
+		)
+	}
 }
 
 func (c *DomainStatsCollector) collectBalloon(uuid string, stat libvirt.DomainStats, ch chan<- prometheus.Metric) {


### PR DESCRIPTION
using libvirt-4.5.0-23.el7_7.5.x86_64 on CentOS 7

This was the obvious fix... any ideas if it's the right way to fix it?

I can reproduce the problem easily to test alternative fixes.