### PR TITLE
Fix metrics resource failure for empty interface names

### DIFF
--- a/collectors/domain_stats.go
+++ b/collectors/domain_stats.go
@@ -603,47 +603,55 @@ func (c *DomainStatsCollector) collectVcpu(uuid string, stat libvirt.DomainStats
 }
 
 func (c *DomainStatsCollector) collectNet(uuid string, stat libvirt.DomainStats, ch chan<- prometheus.Metric) {
+	var ifIndex int
+	ifIndex = 0
 	for _, netStats := range stat.Net {
+		var ifName string
+		ifName = netStats.Name
+		if len(ifName) == 0 {
+			ifName = strconv.Itoa(ifIndex)
+		}
 		ch <- prometheus.MustNewConstMetric(
 			c.DomainNetRxBytes,
 			prometheus.CounterValue,
-			float64(netStats.RxBytes), uuid, netStats.Name,
+			float64(netStats.RxBytes), uuid, ifName,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.DomainNetRxPkts,
 			prometheus.CounterValue,
-			float64(netStats.RxPkts), uuid, netStats.Name,
+			float64(netStats.RxPkts), uuid, ifName,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.DomainNetRxErrs,
 			prometheus.CounterValue,
-			float64(netStats.RxErrs), uuid, netStats.Name,
+			float64(netStats.RxErrs), uuid, ifName,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.DomainNetRxDrop,
 			prometheus.CounterValue,
-			float64(netStats.RxDrop), uuid, netStats.Name,
+			float64(netStats.RxDrop), uuid, ifName,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.DomainNetTxBytes,
 			prometheus.CounterValue,
-			float64(netStats.TxBytes), uuid, netStats.Name,
+			float64(netStats.TxBytes), uuid, ifName,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.DomainNetTxPkts,
 			prometheus.CounterValue,
-			float64(netStats.TxPkts), uuid, netStats.Name,
+			float64(netStats.TxPkts), uuid, ifName,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.DomainNetTxErrs,
 			prometheus.CounterValue,
-			float64(netStats.TxErrs), uuid, netStats.Name,
+			float64(netStats.TxErrs), uuid, ifName,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			c.DomainNetTxDrop,
 			prometheus.GaugeValue,
-			float64(netStats.TxDrop), uuid, netStats.Name,
+			float64(netStats.TxDrop), uuid, ifName,
 		)
+		ifIndex++
 	}
 }
 


### PR DESCRIPTION
We've been encountering errors from the exporter when an instance has multiple SRIOV interfaces attached. It appears that these are reported with a null or zero-length interface name, resulting in errors like:

```
An error has occurred while serving metrics:

8 error(s) occurred:
* collected metric "libvirtd_domain_net_rx_bytes" { label:<name:"interface" value:"" > label:<name:"uuid" value:"40e776cf-2187-4b73-9ab5-9168a1c567da" > counter:<value:0 > } was collected before with the same name and label values
* collected metric "libvirtd_domain_net_rx_packets" { label:<name:"interface" value:"" > label:<name:"uuid" value:"40e776cf-2187-4b73-9ab5-9168a1c567da" > counter:<value:0 > } was collected before with the same name and label values
* collected metric "libvirtd_domain_net_rx_errors" { label:<name:"interface" value:"" > label:<name:"uuid" value:"40e776cf-2187-4b73-9ab5-9168a1c567da" > counter:<value:0 > } was collected before with the same name and label values
* collected metric "libvirtd_domain_net_rx_drop" { label:<name:"interface" value:"" > label:<name:"uuid" value:"40e776cf-2187-4b73-9ab5-9168a1c567da" > counter:<value:0 > } was collected before with the same name and label values
* collected metric "libvirtd_domain_net_tx_bytes" { label:<name:"interface" value:"" > label:<name:"uuid" value:"40e776cf-2187-4b73-9ab5-9168a1c567da" > counter:<value:0 > } was collected before with the same name and label values
* collected metric "libvirtd_domain_net_tx_packets" { label:<name:"interface" value:"" > label:<name:"uuid" value:"40e776cf-2187-4b73-9ab5-9168a1c567da" > counter:<value:0 > } was collected before with the same name and label values
* collected metric "libvirtd_domain_net_tx_errors" { label:<name:"interface" value:"" > label:<name:"uuid" value:"40e776cf-2187-4b73-9ab5-9168a1c567da" > counter:<value:0 > } was collected before with the same name and label values
* collected metric "libvirtd_domain_net_tx_drop" { label:<name:"interface" value:"" > label:<name:"uuid" value:"40e776cf-2187-4b73-9ab5-9168a1c567da" > gauge:<value:0 > } was collected before with the same name and label values
```

As a workaround, I've patched the code to set the interface name to an index when no other name is available.

I'm not at all familiar with Go, so I suspect this patch may need tidying up a bit, but hopefully it's useful.