### PR TITLE
[ATMOSPHERE-351] Fix nova metadata can't be parsed correctly

### DIFF
--- a/collectors/domain_stats.go
+++ b/collectors/domain_stats.go
@@ -710,7 +710,7 @@ func (c *DomainStatsCollector) collectBlock(uuid string, stat libvirt.DomainStat
 func (c *DomainStatsCollector) getNovaMetadata(domain *libvirt.Domain) (*NovaMetadata, error) {
 	data, err := domain.GetMetadata(
 		libvirt.DOMAIN_METADATA_ELEMENT,
-		"http://openstack.org/xmlns/libvirt/nova/1.0",
+		"http://openstack.org/xmlns/libvirt/nova/1.1",
 		libvirt.DOMAIN_AFFECT_LIVE,
 	)
 	if err != nil {


### PR DESCRIPTION
Fixes #11

Depends-On: https://github.com/vexxhost/libvirtd_exporter/pull/13